### PR TITLE
Transfer tensors to GPU in the example snippet of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ from soft_dtw_cuda import SoftDTW
 batch_size, len_x, len_y, dims = 8, 15, 12, 5
 x = torch.rand((batch_size, len_x, dims), requires_grad=True)
 y = torch.rand((batch_size, len_y, dims))
+# Transfer tensors to the GPU
+x = x.cuda()
+y = y.cuda()
 
 # Create the "criterion" object
 sdtw = SoftDTW(use_cuda=True, gamma=0.1)


### PR DESCRIPTION
Current example occurs TypeError. (see #14 )
I added two lines to the example in README.
```
x = x.cuda()
y = y.cuda()
```
