### PR TITLE
enable numba cpu parallelisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 Soft DTW for PyTorch in CUDA
 ===
-Fast CUDA implementation of [soft-DTW](https://github.com/mblondel/soft-dtw) for PyTorch. 
+Fast CUDA implementation of [soft-DTW](https://github.com/mblondel/soft-dtw) for PyTorch.
 Based on [pytorch-softdtw](https://github.com/Sleepwalking/pytorch-softdtw) but can run up to 100x faster!
 Both `forward()` and `backward()` passes are implemented using CUDA.
 
-My implementation is partly inspired by 
+My implementation is partly inspired by
 [_"Developing a pattern discovery method in time series data and its GPU acceleration"_](https://ieeexplore.ieee.org/document/8400444)
-wherein a diagonal-based implementation of the Belman recursion is proposed. 
+wherein a diagonal-based implementation of the Belman recursion is proposed.
 
 ## Getting Started
 
-This code depends on [PyTorch](https://pytorch.org/) and [Numba](http://numba.pydata.org/). 
+This code depends on [PyTorch](https://pytorch.org/) and [Numba](http://numba.pydata.org/).
 Just include `soft_dtw_cuda.py` in your projects, and you should be good to go!
 
 You can also run the included profiler/test (tested with Python v3.6), and see the speedups you'd get:
@@ -79,10 +79,10 @@ If you use this code in your research, please cite the following publications:
 ## FAQ:
 
 ### This is awesome! What can I do to help?
-Consider starring this repository if you find it helpful. Also, don't forget to thank the author of 
+Consider starring this repository if you find it helpful. Also, don't forget to thank the author of
 [pytorch-softdtw](https://github.com/Sleepwalking/pytorch-softdtw) for his CPU implementation.
 
-Also, please consider contributing to this project by improving the performance, addressing existing 
+Also, please consider contributing to this project by improving the performance, addressing existing
 limitations, etc. PRs are greatly welcome!
 
 ### Does it support pruning?
@@ -91,33 +91,33 @@ Yes! Use the `bandwitdh` argument to specify the Sakoe-Chiba bandwidth to use fo
 ### How fast does it run?
 It depends on your batch size and sequence length. The longer the sequences and the larger the batch size,
 the faster this code runs.
- 
-Here's what I get with Ryzen 9 3900x and Titan RTX:
+
+Here's what I get with Intel Core-i7 12700K and Titan RTX:
 
 ```
 Profiling forward() + backward() times for batch_size=128, seq_len_a=17, seq_len_b=15, dims=2...
-	CPU:      0.006849725800202577
-	GPU:      0.0017813925996961189
-	Speedup:  3.8451522709654493
+    CPU:      0.004228143487125635
+    GPU:      0.0014472737908363341
+    Speedup:  2.9214537801325924
 
 Profiling forward() + backward() times for batch_size=512, seq_len_a=64, seq_len_b=64, dims=2...
-	CPU:      0.23511007620036253
-	GPU:      0.0038500409998960096
-	Speedup:  61.06690193863206
+    CPU:      0.023894597217440604
+    GPU:      0.003414902277290821
+    Speedup:  6.997154025853163
 
 Profiling forward() + backward() times for batch_size=512, seq_len_a=256, seq_len_b=256, dims=2...
-	CPU:      3.7511388037995856
-	GPU:      0.03190629960008664
-	Speedup:  117.5673409582539
+    CPU:      0.5894654761068523
+    GPU:      0.0343648319132626
+    Speedup:  17.153160463425888
 ```
 
-Note that there are tons of opportunities for optimizing this code further (e.g. various 
+Note that there are tons of opportunities for optimizing this code further (e.g. various
 CUDA optimizations such as the use shared memory, etc.). Contributions/improvements are greatly appreciated!
 
 ### How accurate are the results?
 Depends on the length of your inputs. Because of the sequential nature of this code, the longer your input
 sequences are, the higher numerical errors become due to accumulation. Especially in the `backward()` call,
-you could see floating point errors of up to `1e-3` on uniform random inputs in the range `[0, 1)` in the 
+you could see floating point errors of up to `1e-3` on uniform random inputs in the range `[0, 1)` in the
 resulting derivative tensor.
 
 The unit tests included in `soft_dtw_cuda.py` verify the results against the CPU implementation.
@@ -126,15 +126,15 @@ The unit tests included in `soft_dtw_cuda.py` verify the results against the CPU
 Some limitations are:
 
 1. All sequences in the same batch should have the same length / number of features.
-2. Inputs cannot have lengths longer than 1024 (due to CUDA limitations on the maximum block size). 
-   The code will warn if your sequence length is too long, and will fall-back to the CPU implementation. 
+2. Inputs cannot have lengths longer than 1024 (due to CUDA limitations on the maximum block size).
+   The code will warn if your sequence length is too long, and will fall-back to the CPU implementation.
 3. You may run out of CUDA resources if your inputs are long (but still less than 1024). See below.
 
 ### I'm seeing `CUDA_ERROR_LAUNCH_OUT_OF_RESOURCES`. Help!
 This means the length of your sequences is too long, and your GPU cannot spawn a sufficient number of threads.
 This is related to point 4 above in the "limitations". I'm not sure if it's possible to query the CUDA device
 in Numba to see if launching the kernel is possible given the number of necessary threads. In these cases
-consider using the CPU implementation.  
+consider using the CPU implementation.
 
 License
 ---

--- a/soft_dtw_cuda.py
+++ b/soft_dtw_cuda.py
@@ -24,7 +24,7 @@
 import numpy as np
 import torch
 import torch.cuda
-from numba import jit
+from numba import jit, prange
 from torch.autograd import Function
 from numba import cuda
 import math
@@ -181,14 +181,14 @@ class _SoftDTWCUDA(Function):
 # I've added support for batching and pruning.
 #
 # ----------------------------------------------------------------------------------------------------------------------
-@jit(nopython=True)
+@jit(nopython=True, parallel=True)
 def compute_softdtw(D, gamma, bandwidth):
     B = D.shape[0]
     N = D.shape[1]
     M = D.shape[2]
     R = np.ones((B, N + 2, M + 2)) * np.inf
     R[:, 0, 0] = 0
-    for b in range(B):
+    for b in prange(B):
         for j in range(1, M + 1):
             for i in range(1, N + 1):
 
@@ -206,7 +206,7 @@ def compute_softdtw(D, gamma, bandwidth):
     return R
 
 # ----------------------------------------------------------------------------------------------------------------------
-@jit(nopython=True)
+@jit(nopython=True, parallel=True)
 def compute_softdtw_backward(D_, R, gamma, bandwidth):
     B = D_.shape[0]
     N = D_.shape[1]
@@ -218,7 +218,7 @@ def compute_softdtw_backward(D_, R, gamma, bandwidth):
     R[:, :, -1] = -np.inf
     R[:, -1, :] = -np.inf
     R[:, -1, -1] = R[:, -2, -2]
-    for k in range(B):
+    for k in prange(B):
         for j in range(M, 0, -1):
             for i in range(N, 0, -1):
 
@@ -412,9 +412,9 @@ def profile(batch_size, seq_len_a, seq_len_b, dims, tol_backward):
     # Average and log
     avg_cpu = np.mean(times_cpu)
     avg_gpu = np.mean(times_gpu)
-    print("\tCPU:     ", avg_cpu)
-    print("\tGPU:     ", avg_gpu)
-    print("\tSpeedup: ", avg_cpu / avg_gpu)
+    print("  CPU:     ", avg_cpu)
+    print("  GPU:     ", avg_gpu)
+    print("  Speedup: ", avg_cpu / avg_gpu)
     print()
 
 # ----------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This PR facilitates parallel computation for the CPU by indicating to Numba that the batch dimensions can be computed independently.

see: https://numba.pydata.org/numba-doc/latest/user/parallel.html#explicit-parallel-loops