### PR TITLE
pairwise distance computation with smaller memory footprint

### DIFF
--- a/soft_dtw_cuda.py
+++ b/soft_dtw_cuda.py
@@ -321,12 +321,10 @@ class SoftDTW(torch.nn.Module):
         """
         Calculates the Euclidean distance between each element in x and y per timestep
         """
-        n = x.size(1)
-        m = y.size(1)
-        d = x.size(2)
-        x = x.unsqueeze(2).expand(-1, n, m, d)
-        y = y.unsqueeze(1).expand(-1, n, m, d)
-        return torch.pow(x - y, 2).sum(3)
+        x_norm = (x**2).sum(-1).unsqueeze(-1)
+        y_norm = (y**2).sum(-1).unsqueeze(-2)
+        dist = x_norm + y_norm - 2.0 * torch.bmm(x, y.mT)
+        return torch.clamp(dist, 0.0, np.inf)
 
     def forward(self, X, Y):
         """


### PR DESCRIPTION
This PR aims at mitigating the high memory cost of the pairwise computation by avoiding broadcasting between x and y. This is pointed out in #19.

The computation seems tricky to get right. This [post](https://discuss.pytorch.org/t/efficient-distance-matrix-computation/9065/10) shows that this method can be unstable (understand some rounding errors), but the alternative from torch ([doc](https://pytorch.org/docs/stable/generated/torch.cdist.html)) does seem to suffer from the same memory [problem](https://github.com/pytorch/pytorch/issues/24345).

This was tested like so:

```
In [1]: import torch

In [2]: a = torch.rand((100, 40, 15))

In [3]: b = torch.rand((100, 50, 15))

In [4]: def _euclidean_dist_func(x, y):
   ...:     """
   ...:     Calculates the Euclidean distance between each element in x and y per timestep
   ...:     """
   ...:     n = x.size(1)
   ...:     m = y.size(1)
   ...:     d = x.size(2)
   ...:     x = x.unsqueeze(2).expand(-1, n, m, d)
   ...:     y = y.unsqueeze(1).expand(-1, n, m, d)
   ...:     return torch.pow(x - y, 2).sum(3)
   ...: 

In [5]: def pairwise_l2_squared(x, y):
   ...:     x_norm = (x**2).sum(-1).unsqueeze(-1)
   ...:     y_norm = (y**2).sum(-1).unsqueeze(-2)
   ...:     dist = x_norm + y_norm - 2.0 * torch.bmm(x, y.mT)
   ...:     return torch.clamp(dist, 0.0, torch.inf)
   ...: 

In [6]: res_a = _euclidean_dist_func(a, b)

In [7]: res_b = pairwise_l2_squared(a, b)

In [8]: torch.allclose(res_a, res_b)
Out[8]: True
```