### PR TITLE
Sakoe chiba band

### DIFF
--- a/soft_dtw_cuda.py
+++ b/soft_dtw_cuda.py
@@ -193,7 +193,10 @@ def compute_softdtw(D, gamma, bandwidth):
             for i in range(1, N + 1):
 
                 # Check the pruning condition
-                if 0 < bandwidth < np.abs(i - j):
+                i_sc, j_sc = i, j
+                if M > N: i_sc = i * M / N
+                if M < N: j_sc = j * N / M
+                if 0 < bandwidth < np.abs(i_sc - j_sc):
                     continue
 
                 r0 = -R[b, i - 1, j - 1] / gamma
@@ -226,7 +229,10 @@ def compute_softdtw_backward(D_, R, gamma, bandwidth):
                     R[k, i, j] = -np.inf
 
                 # Check the pruning condition
-                if 0 < bandwidth < np.abs(i - j):
+                i_sc, j_sc = i, j
+                if M > N: i_sc = i * M / N
+                if M < N: j_sc = j * N / M
+                if 0 < bandwidth < np.abs(i_sc - j_sc):
                     continue
 
                 a0 = (R[k, i + 1, j] - R[k, i, j] - D[k, i + 1, j]) / gamma

--- a/soft_dtw_cuda.py
+++ b/soft_dtw_cuda.py
@@ -64,8 +64,8 @@ def compute_softdtw_cuda(D, gamma, bandwidth, max_i, max_j, n_passes, R):
 
             # Don't compute if outside bandwidth
             i_sc, j_sc = i, j
-            if M > N: i_sc = i * M / N
-            if M < N: j_sc = j * N / M
+            if max_j > max_i: i_sc = i * max_j / max_i
+            if max_j < max_i: j_sc = j * max_i / max_j
             if not (abs(i_sc - j_sc) > bandwidth > 0):
                 r0 = -R[b, i - 1, j - 1] * inv_gamma
                 r1 = -R[b, i - 1, j] * inv_gamma
@@ -106,8 +106,8 @@ def compute_softdtw_backward_cuda(D, R, inv_gamma, bandwidth, max_i, max_j, n_pa
 
             # Don't compute if outside bandwidth
             i_sc, j_sc = i, j
-            if M > N: i_sc = i * M / N
-            if M < N: j_sc = j * N / M
+            if max_j > max_i: i_sc = i * max_j / max_i
+            if max_j < max_i: j_sc = j * max_i / max_j
             if not (abs(i_sc - j_sc) > bandwidth > 0):
                 a = math.exp((R[k, i + 1, j] - R[k, i, j] - D[k, i + 1, j]) * inv_gamma)
                 b = math.exp((R[k, i, j + 1] - R[k, i, j] - D[k, i, j + 1]) * inv_gamma)

--- a/soft_dtw_cuda.py
+++ b/soft_dtw_cuda.py
@@ -61,8 +61,12 @@ def compute_softdtw_cuda(D, gamma, bandwidth, max_i, max_j, n_passes, R):
 
         # Only compute if element[i, j] is on the current anti-diagonal, and also is within bounds
         if I + J == p and (I < max_i and J < max_j):
+
             # Don't compute if outside bandwidth
-            if not (abs(i - j) > bandwidth > 0):
+            i_sc, j_sc = i, j
+            if M > N: i_sc = i * M / N
+            if M < N: j_sc = j * N / M
+            if not (abs(i_sc - j_sc) > bandwidth > 0):
                 r0 = -R[b, i - 1, j - 1] * inv_gamma
                 r1 = -R[b, i - 1, j] * inv_gamma
                 r2 = -R[b, i, j - 1] * inv_gamma
@@ -101,7 +105,10 @@ def compute_softdtw_backward_cuda(D, R, inv_gamma, bandwidth, max_i, max_j, n_pa
                 R[k, i, j] = -math.inf
 
             # Don't compute if outside bandwidth
-            if not (abs(i - j) > bandwidth > 0):
+            i_sc, j_sc = i, j
+            if M > N: i_sc = i * M / N
+            if M < N: j_sc = j * N / M
+            if not (abs(i_sc - j_sc) > bandwidth > 0):
                 a = math.exp((R[k, i + 1, j] - R[k, i, j] - D[k, i + 1, j]) * inv_gamma)
                 b = math.exp((R[k, i, j + 1] - R[k, i, j] - D[k, i, j + 1]) * inv_gamma)
                 c = math.exp((R[k, i + 1, j + 1] - R[k, i, j] - D[k, i + 1, j + 1]) * inv_gamma)


### PR DESCRIPTION
This PR implement some way of using the [Sakoe-Chiba bands](https://pyts.readthedocs.io/en/stable/auto_examples/metrics/plot_sakoe_chiba.html) for non-squared matrices. It does so by computing the approximate diagonal: the indices of the smallest input matrix are interpolated onto the indices of the biggest input matrix. This should address #8 and #18.

The case where N=4, M=7 and bandwidth=1 gives something similar to:
D = [
[x, x, -, -, -, -, -]
[-, x, x, -, -, -, -]
[-, -, -, x, x, -, -]
[-, -, -, -, -, x, x]
]

Note that:
- the rounding in the interpolation of the indices (for instance, i_sc = i * N / M) could be formalised. I did not look too much into it.
- other way of providing the input could be implemented, for example using a relative size as mentioned in the doc linked above.

```
This was tested like so:
In [1]: import torch

In [2]: import soft_dtw_cuda

In [3]: a = torch.rand((100, 40, 15))

In [4]: b = torch.rand((100, 50, 15))

In [5]: sdtw_cpu_sc3 = soft_dtw_cuda.SoftDTW(False, bandwidth=3)

In [6]: res_a = sdtw_cpu_sc3(a, b)

In [7]: torch.any(res_a == torch.inf)
Out[7]: tensor(False)

In [8]: sdtw_gpu_sc3 = soft_dtw_cuda.SoftDTW(True, bandwidth=3)

In [9]: res_b = sdtw_gpu_sc3(a.cuda(), b.cuda())

In [10]: torch.any(res_b == torch.inf)
Out[10]: tensor(False, device='cuda:0')

In [11]: torch.allclose(res_a, res_b.cpu())
Out[11]: True
```